### PR TITLE
Allow string keys in parsed results

### DIFF
--- a/lib/caylir/graph/request.ex
+++ b/lib/caylir/graph/request.ex
@@ -25,6 +25,7 @@ defmodule Caylir.Graph.Request do
 
     case response do
       {:ok, _, %{error: reason}} -> {:error, reason}
+      {:ok, _, %{"error" => reason}} -> {:error, reason}
       {:ok, 200, _success} -> :ok
     end
   end
@@ -49,7 +50,9 @@ defmodule Caylir.Graph.Request do
 
     case response do
       {:ok, _, %{error: reason}} -> {:error, reason}
+      {:ok, _, %{"error" => reason}} -> {:error, reason}
       {:ok, 200, %{result: result}} -> result
+      {:ok, 200, %{"result" => result}} -> result
     end
   end
 
@@ -70,6 +73,7 @@ defmodule Caylir.Graph.Request do
 
     case response do
       {:ok, _, %{error: reason}} -> {:error, reason}
+      {:ok, _, %{"error" => reason}} -> {:error, reason}
       {:ok, 200, shape} -> shape
     end
   end
@@ -95,6 +99,7 @@ defmodule Caylir.Graph.Request do
 
     case response do
       {:ok, _, %{error: reason}} -> {:error, reason}
+      {:ok, _, %{"error" => reason}} -> {:error, reason}
       {:ok, 200, _content} -> :ok
     end
   end


### PR DESCRIPTION
I noticed that I was getting atoms in some of my keys, but everywhere else that I use `Jason.decode/1`, I get strings. This causes problems when trying to pattern match some query results. So I updated the config with this:
```
  json_decoder: {Jason, :decode!},
  json_encoder: {Jason, :encode!}
```
And I got errors:
```
[error] GenServer #PID<0.504.0> terminating
** (CaseClauseError) no case clause matching: {:ok, 200, %{"result" => [%{"stuff" => "asdfasdfasdf"}]}}
    (caylir) lib/caylir/graph/request.ex:50: Caylir.Graph.Request.query/3
```